### PR TITLE
Fix/547 classroom fragment trans

### DIFF
--- a/app/src/main/java/com/nadosunbae_android/app/presentation/ui/classroom/ClassRoomMainContentFragment.kt
+++ b/app/src/main/java/com/nadosunbae_android/app/presentation/ui/classroom/ClassRoomMainContentFragment.kt
@@ -89,27 +89,27 @@ class ClassRoomMainContentFragment : BaseFragment<FragmentClassRoomMainContentBi
             switchTab = CustomSwitchTab.getSwitchTabValue(0)
             switchText = listOf(getString(R.string.classroom_review_tab), getString(R.string.classroom_question_tab))
             itemClickListener = {
-                if (it != classRoomMainContentViewModel.curFragment.value && !(it == 0 && classRoomMainContentViewModel.curFragment.value == -1)) {
-                    switchTab = CustomSwitchTab.getSwitchTabValue(it)
+                if (it != classRoomMainContentViewModel.curFragment.value)
                     classRoomMainContentViewModel.curFragment.postValue(it)
-                }
             }
         }
     }
 
     private fun observeFragmentNum() {
         classRoomMainContentViewModel.curFragment.observe(viewLifecycleOwner) {
-            when (it) {
-                0 -> {
-                    binding.navHostClassroom.findNavController()
-                        .navigate(R.id.action_Classroom_Question_to_Review)
-                }
-                1 -> {
-                    binding.navHostClassroom.findNavController()
-                        .navigate(R.id.action_Classroom_Review_to_Question)
+            if (it != null && binding.viewClassroomSwitch.selectedTab != it) {
+                binding.viewClassroomSwitch.setTabNum(it)
+                when (it) {
+                    0 -> {
+                        binding.navHostClassroom.findNavController()
+                            .navigate(R.id.action_Classroom_Question_to_Review)
+                    }
+                    1 -> {
+                        binding.navHostClassroom.findNavController()
+                            .navigate(R.id.action_Classroom_Review_to_Question)
+                    }
                 }
             }
-            binding.viewClassroomSwitch.switchTab = CustomSwitchTab.getSwitchTabValue(it)
         }
     }
 

--- a/app/src/main/java/com/nadosunbae_android/app/presentation/ui/classroom/SeniorFragment.kt
+++ b/app/src/main/java/com/nadosunbae_android/app/presentation/ui/classroom/SeniorFragment.kt
@@ -1,7 +1,9 @@
 package com.nadosunbae_android.app.presentation.ui.classroom
 
+import android.content.Context
 import android.os.Bundle
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.activityViewModels
 import com.nadosunbae_android.app.R
 import com.nadosunbae_android.app.databinding.FragmentSeniorBinding
@@ -10,6 +12,7 @@ import com.nadosunbae_android.app.presentation.ui.classroom.adapter.ClassRoomSen
 import com.nadosunbae_android.app.presentation.ui.classroom.adapter.ClassRoomSeniorOnAdapter
 import com.nadosunbae_android.app.presentation.ui.classroom.question.DataToFragment
 import com.nadosunbae_android.app.presentation.ui.classroom.review.ReviewGlobals
+import com.nadosunbae_android.app.presentation.ui.main.MainActivity
 import com.nadosunbae_android.app.presentation.ui.main.viewmodel.MainViewModel
 import com.nadosunbae_android.domain.model.classroom.ClassRoomSeniorData
 import dagger.hilt.android.AndroidEntryPoint
@@ -22,6 +25,7 @@ class SeniorFragment : BaseFragment<FragmentSeniorBinding>(R.layout.fragment_sen
     var link = SeniorDataToFragment()
 
     private val mainViewModel: MainViewModel by activityViewModels()
+    private lateinit var callback: OnBackPressedCallback
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -30,6 +34,21 @@ class SeniorFragment : BaseFragment<FragmentSeniorBinding>(R.layout.fragment_sen
         changeTitle()
         observeLoadingEnd()
         loadServerData()
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        callback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                goBack()
+            }
+        }
+        requireActivity().onBackPressedDispatcher.addCallback(this, callback)
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        callback.remove()
     }
 
     //로딩 종료
@@ -69,15 +88,17 @@ class SeniorFragment : BaseFragment<FragmentSeniorBinding>(R.layout.fragment_sen
         val majorId = ReviewGlobals.selectedMajor?.majorId
         if (majorId != null) {
             mainViewModel.getClassRoomSenior(majorId)
-            Timber.d("asdfasdf")
         }
     }
 
+    private fun goBack() {
+        mainViewModel.bottomNavItem.value = MainActivity.CLASSROOM_NOBACK
+    }
 
     //뒤로가기
     private fun goQuestionFragment(){
         binding.imgSeniorTitle.setOnClickListener {
-            mainViewModel.classRoomBackFragmentNum.value = 2
+            goBack()
         }
     }
 
@@ -87,6 +108,7 @@ class SeniorFragment : BaseFragment<FragmentSeniorBinding>(R.layout.fragment_sen
             binding.textSeniorTitle.text = it.majorName
         }
     }
+
     inner class SeniorDataToFragment : DataToFragment {
         override fun getSeniorId(seniorId: Int){
             mainViewModel.seniorId.value = seniorId

--- a/app/src/main/java/com/nadosunbae_android/app/presentation/ui/classroom/review/ClassRoomReviewFragment.kt
+++ b/app/src/main/java/com/nadosunbae_android/app/presentation/ui/classroom/review/ClassRoomReviewFragment.kt
@@ -1,4 +1,4 @@
-package com.nadosunbae_android.app.presentation.ui.classroom
+package com.nadosunbae_android.app.presentation.ui.classroom.review
 
 import android.os.Bundle
 import android.view.View

--- a/app/src/main/java/com/nadosunbae_android/app/presentation/ui/community/custom/CustomSwitchTab.kt
+++ b/app/src/main/java/com/nadosunbae_android/app/presentation/ui/community/custom/CustomSwitchTab.kt
@@ -17,6 +17,9 @@ class CustomSwitchTab(context: Context, attrs: AttributeSet? = null) :
     private var titleTwo: TextView
     private var titleThree: TextView
     private var titleFour: TextView
+    private var _selectedTab: Int = 0
+    val selectedTab: Int
+        get() = _selectedTab
 
     //텍스트 클릭
     var itemClickListener: ((Int) -> Unit)? = null
@@ -56,6 +59,11 @@ class CustomSwitchTab(context: Context, attrs: AttributeSet? = null) :
         titleTwo = binding.switchTabTwo
         titleThree = binding.switchTabThree
         titleFour = binding.switchTabFour
+    }
+
+    fun setTabNum(num: Int) {
+        switchTab = getSwitchTabValue(num)
+        _selectedTab = num
     }
 
     //타이틀 선택

--- a/app/src/main/java/com/nadosunbae_android/app/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/nadosunbae_android/app/presentation/ui/main/MainActivity.kt
@@ -9,6 +9,7 @@ import com.nadosunbae_android.app.R
 import com.nadosunbae_android.app.databinding.ActivityMainBinding
 import com.nadosunbae_android.app.presentation.base.BaseActivity
 import com.nadosunbae_android.app.presentation.ui.classroom.*
+import com.nadosunbae_android.app.presentation.ui.classroom.review.ClassRoomReviewFragment
 import com.nadosunbae_android.app.presentation.ui.community.CommunityFragment
 import com.nadosunbae_android.app.presentation.ui.main.viewmodel.MainViewModel
 import com.nadosunbae_android.app.presentation.ui.mypage.AppInfoFragment
@@ -109,8 +110,14 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
                 }
                 CLASSROOM -> {
                     binding.btNvMain.selectedItemId = R.id.navigation_room
-
-                }NOTIFICATION -> {
+                }
+                CLASSROOM_NOBACK -> {
+                    changeFragmentNoBackStack(
+                        R.id.fragment_container_main,
+                        ClassRoomMainContentFragment()
+                    )
+                }
+                NOTIFICATION -> {
                     binding.btNvMain.selectedItemId = R.id.navigation_notice
                 changeFragmentNoBackStack(R.id.fragment_container_main, NotificationFragment())
                 }
@@ -327,5 +334,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
         const val MYPAGE = 4
         const val MYPAGEDIVISION = 5
         const val NOTIFICATION = 6
+        const val CLASSROOM_NOBACK = 7
     }
 }


### PR DESCRIPTION
## 🙋‍♂️ 작업한 내용
- 과방 내 중복된 탭 전환 (후기 -> 후기)로 인한 버그 수정
- 선배 목록에서 과방으로 돌아오는 탭 전환 수정

## 👍 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 과방에서 연결된 탭들의 전환을 잘못 건드리면 다른 뷰에 영향을 줄 수 있어서 일단 추가만 했습니다! 
- SeniorFragment에서 뒤로가기 (물리적/소프트 둘다)를 과방 탭으로 이동하도록 하였는데, 혹시 다른 뷰에서 사용해서 문제가 생길 수 있다면 말씀부탁드릴게요!

## 📸 스크린샷
전환이라 스크린샷은 없습니다!

## 💚 관련 이슈
- Resolved: #547 

