### PR TITLE
[UI] #704 1:1질문 작성뷰 타이틀 문구 변경

### DIFF
--- a/app/src/main/res/layout/activity_question_write.xml
+++ b/app/src/main/res/layout/activity_question_write.xml
@@ -43,7 +43,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="36dp"
                 android:fontFamily="@font/pretendard_medium"
-                android:text="@string/question_write_all"
+                android:text="@string/question_write_one_to_one"
                 android:textColor="@color/origin_black"
                 android:textSize="16sp"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,7 +231,7 @@
 
 
     <!-- 1:1 질문 작성 -->
-    <string name="question_write_one_to_one">1:1질문 작성</string>
+    <string name="question_write_one_to_one">1:1 질문 작성</string>
     <!-- 질문 상세 보기 -->
     <string name="question_detail_title">1:1 질문</string>
     <string name="question_detail_comment">답글 쓰기</string>


### PR DESCRIPTION
## 🙋‍♂️ 작업한 내용
- 질문작성 뷰 타이틀 문구 변경

## 👍 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- QuestionWriteActivity의 타이틀 문구를 변경하였습니다. ViewModel에서 요청 함수보니 1:1 질문 작성 전용인 것 같아서 변경했는데, 혹시 전체 질문 등 같이 쓰는 뷰면 말씀해주세요!

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
<img width="554" alt="Screen Shot 2022-10-27 at 11 22 09" src="https://user-images.githubusercontent.com/37872134/198175846-f73288c2-03f5-4570-b023-ff2b6a7b8c73.png">


## 💚 관련 이슈
- Resolved: #704 

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
